### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/docs/lib_client.js.html
+++ b/docs/lib_client.js.html
@@ -29,7 +29,7 @@
             <pre class="prettyprint source linenums"><code>'use strict';
 
 const Bluebird = require('bluebird');
-const UUID     = require('node-uuid');
+const UUID     = require('uuid');
 const parseURL = require('url-parse');
 const pick     = require('lodash').pick;
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Bluebird = require('bluebird');
-const UUID     = require('node-uuid');
+const UUID     = require('uuid');
 const parseURL = require('url-parse');
 const pick     = require('lodash').pick;
 

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "koa": "^0.21.0",
     "lodash": "^3.9.3",
     "logfmt": "^1.2.0",
-    "node-uuid": "^1.4.3",
     "redis": "^0.12.1",
     "teamster": "^1.2.0",
     "url-parse": "^1.0.1",
+    "uuid": "^3.0.0",
     "ws": "^0.7.2"
   },
   "devDependencies": {

--- a/test/mock-socket.js
+++ b/test/mock-socket.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const UUID = require('node-uuid');
+const UUID = require('uuid');
 
 class MockSocket {
   constructor(pathQuery) {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.